### PR TITLE
Adding 1.10.2 Superuser

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -94,6 +94,7 @@ attack. Creating a new user has to be done via a Python REPL on the same machine
     >>> user.username = 'new_user_name'
     >>> user.email = 'new_user_email@example.com'
     >>> user.password = 'set_the_password'
+    >>> user.superuser = False #set to true if user should be superuser
     >>> session = settings.Session()
     >>> session.add(user)
     >>> session.commit()


### PR DESCRIPTION
The documentation does not tell the users how to create a superuser. This is how you would create one. While the default user normally gets superuser status by default, might be good to add this line so users know how to add superusers.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.
  - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality

- [x] Passes `flake8`
